### PR TITLE
Remove mocha deprecation warning

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
 require "minitest/wscolor"
-require "mocha"
+require "mocha/setup"
 
 require "freeling/analyzer"


### PR DESCRIPTION
I've just followed this recommendation:
**\* Mocha deprecation warning: Change `require 'mocha'` to `require 'mocha/setup'`.
