### PR TITLE
Add missing 'require "stringio"' in analyzer.rb

### DIFF
--- a/lib/freeling/analyzer.rb
+++ b/lib/freeling/analyzer.rb
@@ -1,3 +1,4 @@
+require "stringio"
 require "open3"
 require "hashie/mash"
 require "freeling/analyzer/process_wrapper"


### PR DESCRIPTION
Example usage failed in my machine:

```
t = analyzer.tokens
 => #<Enumerator: #<Enumerator::Generator:0x007fad739716c0>:each>
1.9.3-p362 :007 > t.first
NameError: uninitialized constant FreeLing::Analyzer::StringIO
    from /Users/manuel/.rvm/gems/ruby-1.9.3-p362/gems/freeling-analyzer-0.1.0/lib/freeling/analyzer.rb:91:in `block in read_tokens'
    from /Users/manuel/.rvm/gems/ruby-1.9.3-p362/gems/freeling-analyzer-0.1.0/lib/freeling/analyzer.rb:62:in `each'
    from /Users/manuel/.rvm/gems/ruby-1.9.3-p362/gems/freeling-analyzer-0.1.0/lib/freeling/analyzer.rb:62:in `each'
    from /Users/manuel/.rvm/gems/ruby-1.9.3-p362/gems/freeling-analyzer-0.1.0/lib/freeling/analyzer.rb:62:in `block in tokens'
    from (irb):7:in `each'
    from (irb):7:in `each'
    from (irb):7:in `first'
    from (irb):7
    from /Users/manuel/.rvm/rubies/ruby-1.9.3-p362/bin/irb:16:in `<main>'

```

Seems that there was a missing require in  `analyzer.rb`. Hope this helps!
